### PR TITLE
feat: update workflow to point to clerk spec repo

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     clerk-java-sdk:
         inputs:
-            - location: ./openapi.yml
+            - location: https://raw.githubusercontent.com/clerk/openapi-specs/refs/heads/main/bapi/2021-02-05.yml
         overlays:
             - location: fixes.yml
         registry:


### PR DESCRIPTION
- Clerk BAPI specs can be found here: https://github.com/clerk/openapi-specs