### PR TITLE
fix: return jwt claims from authenticateRequest part of RequestState

### DIFF
--- a/src/main/java/com/clerk/backend_api/helpers/jwks/AuthenticateRequest.java
+++ b/src/main/java/com/clerk/backend_api/helpers/jwks/AuthenticateRequest.java
@@ -1,5 +1,6 @@
 package com.clerk.backend_api.helpers.jwks;
 
+import io.jsonwebtoken.Claims;
 import java.net.HttpCookie;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
@@ -60,12 +61,12 @@ public final class AuthenticateRequest {
         }
 
         try {
-            VerifyToken.verifyToken(sessionToken, verifyTokenOptions);
+            Claims claims = VerifyToken.verifyToken(sessionToken, verifyTokenOptions);
+            return RequestState.signedIn(sessionToken, claims);
         } catch (TokenVerificationException e) {
             return RequestState.signedOut(e.reason());
         }
 
-        return RequestState.signedIn(sessionToken);
     }
 
     /**

--- a/src/main/java/com/clerk/backend_api/helpers/jwks/RequestState.java
+++ b/src/main/java/com/clerk/backend_api/helpers/jwks/RequestState.java
@@ -1,26 +1,30 @@
 package com.clerk.backend_api.helpers.jwks;
 
+import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import com.clerk.backend_api.utils.Utils;
 
 /**
-* RequestState - Authentication State of the request.
-*/
+ * RequestState - Authentication State of the request.
+ */
 public final class RequestState {
 
     private final AuthStatus status;
     private final Optional<AuthErrorReason> authErrorReason;
     private final Optional<TokenVerificationErrorReason> tokenVerificationErrorReason;
     private final Optional<String> token;
+    private final Optional<Claims> claims;
 
     public RequestState(AuthStatus status,
                         Optional<AuthErrorReason> authErrorReason,
                         Optional<TokenVerificationErrorReason> tokenVerificationErrorReason,
-                        Optional<String> token) {
+                        Optional<String> token,
+                        Optional<Claims> claims) {
         Utils.checkNotNull(status, "status");
         Utils.checkNotNull(authErrorReason, "authErrorReason");
         Utils.checkNotNull(tokenVerificationErrorReason, "tokenVerificationErrorReason");
         Utils.checkNotNull(token, "token");
+        Utils.checkNotNull(claims, "claims");
 
         if (authErrorReason.isPresent() && tokenVerificationErrorReason.isPresent()) {
             throw new IllegalArgumentException("Only one of authErrorReason or tokenVerificationErrorReason should be provided.");
@@ -30,15 +34,21 @@ public final class RequestState {
         this.authErrorReason = authErrorReason;
         this.tokenVerificationErrorReason = tokenVerificationErrorReason;
         this.token = token;
+        this.claims = claims;
     }
 
-    public static RequestState signedIn(String token) {
-        return new RequestState(AuthStatus.SIGNED_IN, Optional.empty(), Optional.empty(), Optional.of(token));
+    public static RequestState signedIn(String token, Claims claims) {
+        return new RequestState(AuthStatus.SIGNED_IN,
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(token),
+                                Optional.of(claims));
     }
 
     public static RequestState signedOut(AuthErrorReason reason) {
         return new RequestState(AuthStatus.SIGNED_OUT,
                                 Optional.of(reason),
+                                Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty());
     }
@@ -47,6 +57,7 @@ public final class RequestState {
         return new RequestState(AuthStatus.SIGNED_OUT,
                                 Optional.empty(),
                                 Optional.of(reason),
+                                Optional.empty(),
                                 Optional.empty());
     }
 
@@ -76,5 +87,9 @@ public final class RequestState {
 
     public Optional<String> token() {
         return token;
+    }
+
+    public Optional<Claims> claims() {
+        return claims;
     }
 }

--- a/src/test/java/com/clerk/backend_api/helpers/jwks/AuthenticateRequestTest.java
+++ b/src/test/java/com/clerk/backend_api/helpers/jwks/AuthenticateRequestTest.java
@@ -59,15 +59,18 @@ public class AuthenticateRequestTest {
         if (state.isSignedIn()) {
             assertTrue(state.reason().isEmpty());
             assertEquals(token, state.token().get());
+            assertTrue(state.claims().isPresent());
+            assertTrue(state.claims().get().getSubject().contains("user_"));
+
         } else {
             assertTrue(state.isSignedOut());
             assertEquals(TokenVerificationErrorReason.TOKEN_EXPIRED, state.reason().get());
             assertTrue(state.token().isEmpty());
+            assertTrue(state.claims().isEmpty());
             System.out.println("WARNING: the provided session token is expired.");
         }
     }
 
-    // @EnabledIfEnvironmentVariable(named = "CLERK_SECRET_KEY", matches = ".+")
     @Test
     public void testAuthenticateRequestNoSessionToken() throws URISyntaxException {
         AuthenticateRequestOptions arOptions = AuthenticateRequestOptions //


### PR DESCRIPTION
This PR mirrors [clerk-sdk-python PR#47](https://github.com/clerk/clerk-sdk-python/pull/47) by returning the jwt `Claims` as part of the `RequestState` object when the session token is correctly authenticated.