### PR TITLE
Make ErrorReason public

### DIFF
--- a/src/main/java/com/clerk/backend_api/helpers/jwks/ErrorReason.java
+++ b/src/main/java/com/clerk/backend_api/helpers/jwks/ErrorReason.java
@@ -3,7 +3,7 @@ package com.clerk.backend_api.helpers.jwks;
 /**
  * ErrorReason - Interface implemented by AuthErrorReason and TokenVerificationErrorReason.
  */
-interface ErrorReason {
+public interface ErrorReason {
 
     String id();
 


### PR DESCRIPTION
This PR resolves an issue with accessing the ErrorMessage class and its message() method in a legacy Scala codebase. The change involves adjusting the visibility of the ErrorReason interface to make it explicitly public.

The issue surfaced when integrating the Clerk backend API into a legacy Scala codebase that uses older Jackson libraries. While shading the Jackson library was required for compatibility, it's unclear if this specifically caused the accessibility issue with the ErrorReason interface.

By explicitly marking the interface as public, this change ensures compatibility and resolves the accessibility problem.
The modification is minimal, aligns with Java's standard visibility practices, and avoids unnecessary complexity.