### PR TITLE
fix: update BeforeRequestHook test after BeforeRequestContextImpl signature change

### DIFF
--- a/src/test/java/com/clerk/backend_api/hooks/ClerkBeforeRequestHookTest.java
+++ b/src/test/java/com/clerk/backend_api/hooks/ClerkBeforeRequestHookTest.java
@@ -19,6 +19,7 @@ class ClerkBeforeRequestHookTest {
 
         // Instantiate BeforeRequestContext using its implementation
         BeforeRequestContext context = new BeforeRequestContextImpl(
+            "http://example.com", // Provide a mock Base URL
             "test-operation-id", // Provide a mock operation ID
             Optional.empty(), // No OAuth scopes needed
             Optional.empty() // No SecuritySource needed


### PR DESCRIPTION
This PR updates the `ClerkBeforeRequestHookTest` to account for `BeforeRequestContextImpl` signature having changed (now includes a `baseURL` argument)

