### PR TITLE
Fix cookie parsing

### DIFF
--- a/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
+++ b/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
@@ -8,14 +8,11 @@ import com.clerk.backend_api.helpers.security.models.TokenVerificationException;
 import com.clerk.backend_api.helpers.security.models.TokenVerificationResponse;
 import com.clerk.backend_api.helpers.security.models.VerifyTokenOptions;
 import java.io.IOException;
-import java.net.HttpCookie;
-import java.net.http.HttpHeaders;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.clerk.backend_api.helpers.security.util.TokenTypeHelper.getTokenType;
 

--- a/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
+++ b/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
@@ -91,7 +91,7 @@ public final class AuthenticateRequest {
         return Arrays.stream(cookieHeaders.get(0).split(";"))
                 .map(String::trim)
                 .map(s -> s.split("=", 2))       // ["name","value"]
-                .filter(kv -> kv[0].equals("__session") || !kv[0].startsWith("__session"))
+                .filter(kv -> kv[0].startsWith("__session"))
                 .map(kv -> kv[1])
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
+++ b/src/main/java/com/clerk/backend_api/helpers/security/AuthenticateRequest.java
@@ -9,10 +9,13 @@ import com.clerk.backend_api.helpers.security.models.TokenVerificationResponse;
 import com.clerk.backend_api.helpers.security.models.VerifyTokenOptions;
 import java.io.IOException;
 import java.net.HttpCookie;
+import java.net.http.HttpHeaders;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.clerk.backend_api.helpers.security.util.TokenTypeHelper.getTokenType;
 
@@ -85,17 +88,16 @@ public final class AuthenticateRequest {
         }
 
         List<String> cookieHeaders = lowerCaseHeaders.get("cookie");
-        if (cookieHeaders != null && !cookieHeaders.isEmpty()) {
-            String cookieHeaderValue = cookieHeaders.get(0);
-            List<HttpCookie> cookies = HttpCookie.parse(cookieHeaderValue);
-            for (HttpCookie cookie : cookies) {
-                if (cookie.getName().startsWith(SESSION_COOKIE_NAME)) {
-                    return cookie.getValue();
-                }
-            }
+        if (cookieHeaders == null || cookieHeaders.isEmpty()) {
+            return null;
         }
-
-        return null;
+        return Arrays.stream(cookieHeaders.get(0).split(";"))
+                .map(String::trim)
+                .map(s -> s.split("=", 2))       // ["name","value"]
+                .filter(kv -> kv[0].equals("__session") || !kv[0].startsWith("__session"))
+                .map(kv -> kv[1])
+                .findFirst()
+                .orElse(null);
     }
 
 


### PR DESCRIPTION
Resolves https://github.com/clerk/clerk-sdk-java/issues/69

As reported in the issue - HttpCookie.parse(...) is not meant for the `Cookie` header parsing - it's meant for the `set-cookie` header.

This is a quick fix that doesn't bring in any new deps. 

Existing tests still pass. 