### PR TITLE
chore: Remove placeholders from package info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,8 +130,8 @@ ext {
         groupId: group,
         artifactId: artifactId,
         version: version,
-        name: "My Company Java SDK",
-        description: "SDK enabling Java developers to easily integrate with the My Company API.",
+        name: "Clerk Backend API",
+        description: "The Clerk REST Backend API, meant to be accessed by backend servers.",
         publicationName: "maven"
     ]
 }

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -45,27 +45,23 @@ afterEvaluate {
                     ]
                     name = config.name
                     description = config.description
-                    url = 'https://github.com/owner/repo'
+                    url = 'https://github.com/clerk/clerk-sdk-java'
                     scm {
-                        url = 'github.com/owner/repo'
-                        connection = 'scm:git:ssh://git@github.com/owner/repo.git'
+                        url = 'https://github.com/clerk/clerk-sdk-java'
+                        connection = 'scm:git:ssh://git@github.com/clerk/clerk-sdk-java.git'
                     }
                     licenses {
                         license {
-                            name = 'The MIT License (MIT)'
-                            url = 'https://mit-license.org/'
+                            name = 'MIT License'
+                            url = 'https://github.com/clerk/clerk-sdk-java/blob/main/LICENSE'
                         }
                     }
                     developers {
                         developer {
-                            name = 'My Company'
-                            organization = 'My Company'
-                            email = 'info@mycompany.com'
+                            id = 'clerk'
+                            name = 'Clerk'
+                            url = 'https://clerk.com'
                         }
-                    }
-                    organization {
-                        name = 'My Company'
-                        url = 'www.mycompany.com'
                     }
                 }
             }


### PR DESCRIPTION
It's still "My Company" placeholder data showing up for this package https://central.sonatype.com/artifact/com.clerk/backend-api

I tried to mimic https://github.com/clerk/clerk-android/blob/b63952f3e98ad0e0384e6b52f5b3dc325197088c/source/api/build.gradle.kts#L64, I've never actually published something to Maven before